### PR TITLE
Add optional basic auth

### DIFF
--- a/deploy.env
+++ b/deploy.env
@@ -1,3 +1,6 @@
 AF_BASE_URL=http://localhost
 AF_GOTRUE_URL=http://localhost/gotrue
 AF_WS_URL=ws://localhost/ws/v1
+
+AF_BASIC_AUTH_USER=
+AF_BASIC_AUTH_PWD=

--- a/deploy/server.ts
+++ b/deploy/server.ts
@@ -10,6 +10,8 @@ import pino from 'pino';
 const distDir = path.join(__dirname, 'dist');
 const indexPath = path.join(distDir, 'index.html');
 const baseURL = process.env.AF_BASE_URL as string;
+const basicAuthUser = process.env.AF_BASIC_AUTH_USER || '';
+const basicAuthPwd = process.env.AF_BASIC_AUTH_PWD || '';
 const defaultSite = 'https://appflowy.com';
 
 const setOrUpdateMetaTag = ($: CheerioAPI, selector: string, attribute: string, content: string) => {
@@ -72,12 +74,33 @@ const fetchMetaData = async (namespace: string, publishName?: string) => {
   }
 };
 
+const validateBasicAuth = (authHeader: string | null) => {
+  if (!authHeader || !authHeader.startsWith('Basic ')) return false;
+  try {
+    const decoded = Buffer.from(authHeader.replace('Basic ', ''), 'base64').toString('utf8');
+    const [user, pwd] = decoded.split(':');
+    return user === basicAuthUser && pwd === basicAuthPwd;
+  } catch {
+    return false;
+  }
+};
+
 const createServer = async (req: Request) => {
   const timer = logRequestTimer(req);
   const reqUrl = new URL(req.url);
   const hostname = req.headers.get('host');
 
   logger.info(`Request URL: ${hostname}${reqUrl.pathname}`);
+
+  if (basicAuthUser && basicAuthPwd && reqUrl.pathname === '/login') {
+    if (!validateBasicAuth(req.headers.get('authorization'))) {
+      timer();
+      return new Response('Unauthorized', {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'Basic realm="AppFlowy"' },
+      });
+    }
+  }
 
   if (reqUrl.pathname === '/') {
     timer();

--- a/dev.env
+++ b/dev.env
@@ -1,4 +1,5 @@
 AF_BASE_URL=http://localhost:8000
 AF_GOTRUE_URL=http://localhost:9999
-AF_WS_URL=ws://localhost:8000/ws/v1
-AF_WS_V2_URL=ws://localhost:8000/ws/v2
+AF_WS_URL=ws://localhost:8000/ws/v1AF_WS_V2_URL=ws://localhost:8000/ws/v2
+AF_BASIC_AUTH_USER=
+AF_BASIC_AUTH_PWD=

--- a/doc/DEVELOPMENT_GUIDE.md
+++ b/doc/DEVELOPMENT_GUIDE.md
@@ -45,6 +45,9 @@ cd AppFlowy-Cloud
 # In a new terminal, navigate to your AppFlowy Web directory
 cd /path/to/appflowy-web
 cp dev.env .env
+# Optional: enable basic auth for the login page
+export AF_BASIC_AUTH_USER=myuser
+export AF_BASIC_AUTH_PWD=mypassword
 
 # Install dependencies and start
 corepack enable
@@ -81,6 +84,9 @@ cd /path/to/appflowy-web
 
 # Use matching production configuration
 cp deploy.env .env
+# Optional: enable basic auth for the login page
+export AF_BASIC_AUTH_USER=myuser
+export AF_BASIC_AUTH_PWD=mypassword
 
 # Install dependencies and start
 corepack enable


### PR DESCRIPTION
## Summary
- add optional basic auth credentials to `.env` templates
- support basic auth on `/login` in Bun server
- document basic auth usage in development guide

## Testing
- `pnpm test:unit` *(fails: Request was cancelled because internet access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686e046e594c832596110b831d8de410